### PR TITLE
Update ep

### DIFF
--- a/routes/searchByMenuItem.js
+++ b/routes/searchByMenuItem.js
@@ -40,12 +40,13 @@ router.get('/', async (req, res) => {
                     Restaurant_ID: menuInfo.Restaurant_ID
                 }
             });
-             const tags = await TaggedMenu.findAll ({
+             const tagsOnMenu = await TaggedMenu.findAll ({
                  attributes: ['Tag'],
                  where: {
                      Menu_ID: mi.dataValues.Menu_ID
                  }
              });
+             const tags = await tagsOnMenu.map( m => { return m.dataValues.Tag });
 
              const menu = {
                  menuID: mi.dataValues.Menu_ID,

--- a/routes/searchByMenuItem.js
+++ b/routes/searchByMenuItem.js
@@ -6,6 +6,8 @@ router.use(express.json());
 const Menu = require('../models/menu.js');
 const MenuItem = require('../models/menuItem.js');
 const Restaurant = require('../models/restaurants.js');
+const TaggedMenu = require('../models/taggedMenu.js');
+
 
 const Sequelize = require('sequelize');
 const Op = Sequelize.Op;
@@ -13,7 +15,7 @@ const Op = Sequelize.Op;
 
 
 router.get('/', async (req, res) => {
-    try{
+    try {
         // Find all MenuItems that matches the query-word
         let matchingItems = await MenuItem.findAll({
             attributes: ['Name', 'Menu_ID'],
@@ -21,35 +23,47 @@ router.get('/', async (req, res) => {
                 Name: {[Op.substring]: req.query.menuItemName}
             }
         });
+
         // Find the menus that the matched MenuItems belongs to.
         // There is a problem with the associations between the models. Need to separate the queries for now.
         // Will fix this later on. The actually code can be found at the end of this file.
         let promises =  matchingItems.map(async mi => {
-             const menu = await Menu.findOne({
+             const menuInfo = await Menu.findOne({
                 attributes: ['Name', 'Description', 'Menu_ID', 'Restaurant_ID'],
                 where: {
                     Menu_ID: mi.dataValues.Menu_ID
                 }
             });
-             return menu
-        });
-        let menus = await Promise.all(promises);
-    /*
-
-        let np =  await menus.map(async m => {
-            const result = await Restaurant.findOne({
-                attributes: 'Name',
+            const restaurantData = await Restaurant.findOne({
+                attributes: ['Name'],
                 where: {
-                    Restaurant_ID: m.Restaurant_ID
+                    Restaurant_ID: menuInfo.Restaurant_ID
                 }
             });
-            return {m, result}
+             const tags = await TaggedMenu.findAll ({
+                 attributes: ['Tag'],
+                 where: {
+                     Menu_ID: mi.dataValues.Menu_ID
+                 }
+             });
+
+             const menu = {
+                 menuID: mi.dataValues.Menu_ID,
+                 name: menuInfo.dataValues.Name,
+                 description: menuInfo.dataValues.Description,
+                 tags
+             };
+             return {
+                 restaurantData: {
+                     restaurantID: menuInfo.dataValues.Restaurant_ID,
+                     restaurantName: restaurantData.dataValues.Name,
+                 },
+                 menu}
         });
 
-        let results = await Promise.all(np);
-        */
+        let result = await Promise.all(promises);
 
-        res.status(200).send(menus);
+        res.status(200).send(result);
 
     } catch (error){
         res.status(400).send(error);

--- a/routes/searchByMenuItem.js
+++ b/routes/searchByMenuItem.js
@@ -23,6 +23,7 @@ router.get('/', async (req, res) => {
                 Name: {[Op.substring]: req.query.menuItemName}
             }
         });
+        matchingItems = pruneByMenuID(matchingItems);
 
         // Find the menus that the matched MenuItems belongs to.
         // There is a problem with the associations between the models. Need to separate the queries for now.
@@ -63,13 +64,29 @@ router.get('/', async (req, res) => {
         });
 
         let result = await Promise.all(promises);
-
+        //let i = " " + matchingItems[1].Menu_ID;
         res.status(200).send(result);
 
     } catch (error){
         res.status(400).send(error);
     }
 });
+
+
+const pruneByMenuID = (arr) => {
+    let d = [];
+    for (let i = 0; i < arr.length; i++){
+        let id = arr[i].Menu_ID;
+        if (d.includes(id)){
+            arr.splice(i, 1);
+            i --;
+        } else {
+            d.push(arr[i].Menu_ID);
+        }
+    }
+    return arr
+
+}
 
 module.exports = router;
 

--- a/routes/searchMenu.js
+++ b/routes/searchMenu.js
@@ -30,13 +30,18 @@ router.get('/:menuID', async (req, res) => {
                 Menu_ID: req.params.menuID
             }
         });
+        const tags = await menuTags.map( m => { return m.dataValues.Tag });
+
         const promises =  menuItemsWithoutTags.map(async menuItems => {
-            const tags = await TaggedItem.findAll({
+            const tagsOnItem = await TaggedItem.findAll({
                 attributes: ['Tag'],
                 where: {
                     MI_ID: menuItems.dataValues.MI_ID
                 }
             });
+            const tags = await tagsOnItem.map( m => { return m.dataValues.Tag });
+
+
             return {
                 name: menuItems.dataValues.Name,
                 description: menuItems.dataValues.Description,
@@ -49,7 +54,7 @@ router.get('/:menuID', async (req, res) => {
         res.status(200).send({
             name: menuInfo.dataValues.Name,
             description:  menuInfo.dataValues.Description,
-            tags: menuTags,
+            tags,
             menuItems
         });
     } catch (error){

--- a/routes/searchMenu.js
+++ b/routes/searchMenu.js
@@ -5,23 +5,53 @@ router.use(express.json());
 
 const Menu = require('../models/menu.js');
 const MenuItem = require('../models/menuItem.js');
+const TaggedItem = require('../models/taggedItem.js');
+const TaggedMenu = require('../models/taggedMenu.js');
+
+
 
 router.get('/:menuID', async (req, res) => {
     try {
 
-        let menuInfo = await Menu.findOne({
+        const menuInfo = await Menu.findOne({
             attributes: ['Name', 'Description', 'Menu_ID'],
             where: {
                 Menu_ID: req.params.menuID
             }
         });
-
-        let dishes = await MenuItem.findAll({
+        const menuTags = await TaggedMenu.findAll({
+            attributes: ['Tag'],
             where: {
                 Menu_ID: req.params.menuID
             }
         });
-        res.status(200).send({menuInfo, dishes});
+        const menuItemsWithoutTags= await MenuItem.findAll({
+            where: {
+                Menu_ID: req.params.menuID
+            }
+        });
+        const promises =  menuItemsWithoutTags.map(async menuItems => {
+            const tags = await TaggedItem.findAll({
+                attributes: ['Tag'],
+                where: {
+                    MI_ID: menuItems.dataValues.MI_ID
+                }
+            });
+            return {
+                name: menuItems.dataValues.Name,
+                description: menuItems.dataValues.Description,
+                priceEuros: menuItems.dataValues.Price,
+                imageLink: menuItems.dataValues.ImageLink,
+                tags}
+        });
+        const menuItems = await Promise.all(promises);
+
+        res.status(200).send({
+            name: menuInfo.dataValues.Name,
+            description:  menuInfo.dataValues.Description,
+            tags: menuTags,
+            menuItems
+        });
     } catch (error){
         res.status(400).send(error);
     }


### PR DESCRIPTION
Updated the endpoints:
/api/user/customer/menu/searchByMenuItem
​/api​/user​/customer​/menu​/{menuID}

Now they return the response with the format defined in Swagger.
The searchByMenuItem EP also return a unique set of menus. I.e no duplicates if there are several menuItems from the same menu that matches the query word. 